### PR TITLE
Support variable declarations without an initialiser

### DIFF
--- a/lib/generate.js
+++ b/lib/generate.js
@@ -206,7 +206,7 @@ filepaths = ast
     return item.type == 'VariableDeclaration';
   })
   .filter(function (item) {
-    if (item.declarations[0].init.callee) {
+    if (item.declarations[0].init?.callee) {
       return (
         item.declarations[0].init.callee.name == 'require' &&
         item.declarations[0].init.arguments[0].value.includes('./')

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/simple-ast",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Generates OpenFn/platform readable ASTs for adaptors",
   "homepage": "https://docs.openfn.org",
   "repository": {


### PR DESCRIPTION
I hit a small problem generating the ast for this code in adaptors

```
let anyAscii;
import('any-ascii').then(m => {
  anyAscii = m.default;
});
```
(I know this code is awful - `any-ascii` is pure ESM and fails to load right now in core ANd the new runtime - I'm in the market for a better fix but this gets us moving right now and in this particular case I think this horrible pattern is quite safe).

Anyway the `let anyAscii;` line actually blows up simple ast! This Pr fixes is, enabling us to parse variable declarations without an initialiser